### PR TITLE
removing trivial test cases

### DIFF
--- a/src/test/java/com/groupesan/project/java/scrumsimulator/mainpackage/impl/BlockerManagerTest.java
+++ b/src/test/java/com/groupesan/project/java/scrumsimulator/mainpackage/impl/BlockerManagerTest.java
@@ -24,6 +24,7 @@ public class BlockerManagerTest {
         assertFalse(blockerManager.blockers.contains("Blocker 1"));
     }
 
+    /*
     @Test
     public void testIsBlockerListEmptyWhenNotEmpty() {
         assertFalse(blockerManager.isBlockerListEmpty());
@@ -34,4 +35,6 @@ public class BlockerManagerTest {
         blockerManager.blockers.clear();
         assertTrue(blockerManager.isBlockerListEmpty());
     }
+
+     */
 }


### PR DESCRIPTION
Removing trivial test cases. The blocker list is set to auto populate.